### PR TITLE
Add the 'select' command to allow database selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ end
 
 
 ```ruby
-host    = "127.0.0.1"
-port    = 6379
-key     = "hoge"
+host     = "127.0.0.1"
+port     = 6379
+key      = "hoge"
+database = 0
 
 puts "> redis connect #{host}: #{port.to_s}"
 r = Redis.new host, port
+
+puts "> redis select: #{database}"
+r.select database
 
 puts "> redis set #{key} 200"
 r.set key, "200"
@@ -87,6 +91,7 @@ r.close
 
 ```text
 > redis connect 127.0.0.1: 6379
+> redis select: 0
 > redis set hoge 200
 > redis get hoge
 hoge: 200

--- a/example/redis.rb
+++ b/example/redis.rb
@@ -1,9 +1,13 @@
-host    = "127.0.0.1"
-port    = 6379
-key     = "hoge"
+host     = "127.0.0.1"
+port     = 6379
+key      = "hoge"
+database = 0
 
 puts "> redis connect #{host}: #{port.to_s}"
 r = Redis.new host, port
+
+puts "> redis select: #{database}"
+r.select database
 
 puts "> redis set #{key} 200"
 r.set key, "200"

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -89,6 +89,23 @@ mrb_value mrb_redis_connect(mrb_state *mrb, mrb_value self)
     return self;
 }
 
+mrb_value mrb_redis_select(mrb_state *mrb, mrb_value self)
+{
+    mrb_value database;
+
+    mrb_get_args(mrb, "o", &database);
+    redisContext *rc = mrb_redis_get_context(mrb, self);
+
+    if (mrb_type(database) != MRB_TT_FIXNUM) {
+      mrb_raisef(mrb, E_TYPE_ERROR, "type mismatch: %S given", database);
+    }
+
+    redisReply *rs = redisCommand(rc, "SELECT %d", mrb_fixnum(database));
+    freeReplyObject(rs);
+
+    return  self;
+}
+
 mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
 {
     mrb_value key, val;
@@ -254,6 +271,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
     redis = mrb_define_class(mrb, "Redis", mrb->object_class);
 
     mrb_define_method(mrb, redis, "initialize", mrb_redis_connect, ARGS_ANY());
+    mrb_define_method(mrb, redis, "select", mrb_redis_select, ARGS_REQ(1));
     mrb_define_method(mrb, redis, "set", mrb_redis_set, ARGS_ANY());
     mrb_define_method(mrb, redis, "get", mrb_redis_get, ARGS_ANY());
     mrb_define_method(mrb, redis, "[]=", mrb_redis_set, ARGS_ANY());


### PR DESCRIPTION
Hi,
This commit adds the ability to select a redis database (see http://redis.io/commands/select)
regards
Vincent
