### PR TITLE
Add Redis#zadd, Redis#zrange, Redis#zrevrange, Redis#zrank

### DIFF
--- a/test/redis.rb
+++ b/test/redis.rb
@@ -26,6 +26,35 @@ assert("Redis#exist?") do
   assert_false(r.exists?("fuga"))
 end
 
+assert("Redis#zadd, Redis#zrange") do
+  r = Redis.new "127.0.0.1", 6379
+  r.del("hs")
+  r.zadd("hs", 80, "a")
+  r.zadd("hs", 50.1, "b")
+  r.zadd("hs", 60, "c")
+  assert_equal(["b", "c", "a"], r.zrange("hs", 0, -1))
+end
+
+assert("Redis#zrevrange") do
+  r = Redis.new "127.0.0.1", 6379
+  r.del("hs")
+  r.zadd("hs", 80, "a")
+  r.zadd("hs", 50.1, "b")
+  r.zadd("hs", 60, "c")
+  assert_equal(["a", "c", "b"], r.zrevrange("hs", 0, -1))
+end
+
+assert("Redis#zrank") do
+  r = Redis.new "127.0.0.1", 6379
+  r.del("hs")
+  r.zadd("hs", 80, "a")
+  r.zadd("hs", 50.1, "b")
+  r.zadd("hs", 60, "c")
+  assert_equal(0, r.zrank("hs", "b"))
+  assert_equal(1, r.zrank("hs", "c"))
+  assert_equal(2, r.zrank("hs", "a"))
+end
+
 # TODO: Add test
 # - randomkey
 # - del


### PR DESCRIPTION
Actually ZADD command can have multi sorted sets:

```
ZADD key score member [score member]
```

Redis#zadd can have a sorted set as an arguement but cannot have multi sorted sets.
In the future I want to implement multi sorted sets.
