### PR TITLE
Fix arguments

### DIFF
--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -285,7 +285,7 @@ mrb_value mrb_redis_zadd(mrb_state *mrb, mrb_value self)
     return  self;
 }
 
-mrb_value mrb_redis_basic_zrange(mrb_state *mrb, mrb_value self)
+mrb_value mrb_redis_basic_zrange(mrb_state *mrb, mrb_value self, const char *cmd)
 {
     int i;
     mrb_value list, array;
@@ -309,12 +309,12 @@ mrb_value mrb_redis_basic_zrange(mrb_state *mrb, mrb_value self)
     return array;
 }
 
-mrb_value mrb_redis_zrange(mrb_state *mrb, mrb_value self, const char *cmd)
+mrb_value mrb_redis_zrange(mrb_state *mrb, mrb_value self)
 {
     return mrb_redis_basic_zrange(mrb, self, "ZRANGE");
 }
 
-mrb_value mrb_redis_zrevrange(mrb_state *mrb, mrb_value self, const char *cmd)
+mrb_value mrb_redis_zrevrange(mrb_state *mrb, mrb_value self)
 {
     return mrb_redis_basic_zrange(mrb, self, "ZREVRANGE");
 }


### PR DESCRIPTION
The following func has too many arguments:

```
mrb_value mrb_redis_zrange(mrb_state *mrb, mrb_value self, const char *cmd)
mrb_value mrb_redis_zrevrange(mrb_state *mrb, mrb_value self, const char *cmd)
```

It is not necessary to have cmd arguments:

```
mruby-redis/src/mrb_redis.c:381: warning: passing argument 4 of ‘mrb_define_method’ from incompatible pointer type
mruby-redis/src/mrb_redis.c:382: warning: passing argument 4 of ‘mrb_define_method’ from incompatible pointer type
```

They are correct arguments:

```
mrb_value mrb_redis_zrange(mrb_state *mrb, mrb_value self)
mrb_value mrb_redis_zrevrange(mrb_state *mrb, mrb_value self)
```
