### PR TITLE
Delete warning in mruby test code

### DIFF
--- a/test/redis.rb
+++ b/test/redis.rb
@@ -119,7 +119,7 @@ assert("Redis#decrby") do
 
   r.close
 
-  assert_equal -90, ret
+  assert_equal(-90, ret)
   assert_equal "-90", score
 end
 


### PR DESCRIPTION
Before:

```
/Users/hiroejun/work/mruby-redis/mruby-redis/test/redis.rb:122:17: ambiguous first argument; put parentheses or even spaces
CC    build/host/test/no_mrb_open_test.c -> build/host/test/no_mrb_open_test.o
AR    build/host/test/mrbtest.a 
LD    build/host/test/mrbtest 
>>> Test host <<<
mrbtest - Embeddable Ruby Test
```
