### PR TITLE
enable garbage collection for redis context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-mruby
+/mruby/

--- a/include/mruby/redis.h
+++ b/include/mruby/redis.h
@@ -1,0 +1,23 @@
+#ifndef MRUBY_REDIS_H
+#define MRUBY_REDIS_H
+
+#include <mruby.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define E_REDIS_ERROR (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "ConnectionError"))
+#define E_REDIS_REPLY_ERROR (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "ReplyError"))
+#ifndef E_EOF_ERROR
+#define E_EOF_ERROR (mrb_class_get(mrb, "EOFError"))
+#endif
+#define E_REDIS_ERR_PROTOCOL (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "ProtocolError"))
+#define E_REDIS_ERR_OOM (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "OOMError"))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/mrblib/error.rb
+++ b/mrblib/error.rb
@@ -1,0 +1,7 @@
+unless Object.const_defined?("IOError")
+  class IOError < StandardError; end
+end
+
+unless Object.const_defined?("EOFError")
+  class EOFError < IOError; end
+end

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -798,6 +798,9 @@ static mrb_value mrb_redis_close(mrb_state *mrb, mrb_value self) {
 
   redisFree(rc);
 
+  DATA_PTR(self) = NULL;
+  DATA_TYPE(self) = NULL;
+
   return mrb_nil_value();
 }
 
@@ -805,6 +808,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb) {
   struct RClass *redis;
 
   redis = mrb_define_class(mrb, "Redis", mrb->object_class);
+  MRB_SET_INSTANCE_TT(redis, MRB_TT_DATA);
 
   mrb_define_class_under(mrb, redis, "ConnectionError", E_RUNTIME_ERROR);
 

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -448,6 +448,22 @@ assert("Redis#zcard") do
   assert_equal 2, r.zcard("myzset")
 end
 
+assert("Pipelined commands") do
+  redis = Redis.new HOST, PORT
+  redis.queue(:set, "mruby-redis-test:foo", "bar")
+  redis.queue(:get, "mruby-redis-test:foo")
+  assert_equal(:OK,   redis.reply)
+  assert_equal("bar", redis.reply)
+
+  redis.queue(:set, "mruby-redis-test:foo", "bar")
+  redis.queue(:get, "mruby-redis-test:foo")
+  assert_equal([:OK, "bar"], redis.bulk_reply)
+
+  redis.queue(:nonexistant)
+  assert_kind_of(Redis::ReplyError, redis.reply)
+  redis.del("mruby-redis-test:foo")
+end
+
 #assert("Redis#zrevrange") do
 #  r = Redis.new HOST, PORT
 #  r.del "hs"


### PR DESCRIPTION
```c
MRB_SET_INSTANCE_TT(redis, MRB_TT_DATA);
```
Was missing, so garbage collection wasn't working for a redis context.

Also, ```Redis#close``` could result in a double free, resolved that too.