### PR TITLE
Fix compile error under OS X

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -22,6 +22,8 @@ MRuby::Gem::Specification.new('mruby-redis') do |spec|
     Dir.chdir(build_dir) do
       e = {}
       run_command e, 'git clone git://github.com/redis/hiredis.git'
+      # Latest HIREDIS is not compatible for OS X
+      run_command e, "git --git-dir=#{hiredis_dir}/.git --work-tree=#{hiredis_dir} checkout v0.13.3" if `uname` =~ /Darwin/
     end
   end
 


### PR DESCRIPTION
Hi, I failed compile error under the OS X.
`HIREDIS` is now version 1.0, 1.0 not compatible under the OS X.

I got a below error.

```
build: [exec] git clone git://github.com/redis/hiredis.git
Cloning into 'hiredis'...
build: [exec] make
make[1]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
clang -g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -Wwrite-strings -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  net.c
net.c:139:37: error: use of undeclared identifier 'TCP_KEEPALIVE'
    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &val, sizeof(val)) < 0) {
                                    ^
net.c:433:29: error: use of undeclared identifier 'AF_LOCAL'
    if (redisCreateSocket(c,AF_LOCAL) < 0)
                            ^
net.c:458:21: error: use of undeclared identifier 'AF_LOCAL'
    sa.sun_family = AF_LOCAL;
                    ^
3 errors generated.
make[1]: *** [net.o] Error 1
```

Thanks.