### PR TITLE
declare before for_loop to compatibility

### DIFF
--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -967,6 +967,7 @@ static mrb_value mrb_redisAppendCommandArgv(mrb_state *mrb, mrb_value self)
   argv[0] = mrb_sym2name_len(mrb, command, &command_len);
   argvlen[0] = command_len;
 
+  int argc_current;
   for (mrb_int argc_current = 1; argc_current < argc; argc_current++) {
     mrb_value curr = mrb_str_to_str(mrb, mrb_argv[argc_current - 1]);
     argv[argc_current] = RSTRING_PTR(curr);

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -943,6 +943,7 @@ static inline mrb_value mrb_redis_get_ary_reply(redisReply *reply, mrb_state *mr
 {
   mrb_value ary = mrb_ary_new_capa(mrb, reply->elements);
   int ai = mrb_gc_arena_save(mrb);
+  int element_couter;
   for (size_t element_couter = 0; element_couter < reply->elements; element_couter++) {
     mrb_value element = mrb_redis_get_reply(reply->element[element_couter], mrb);
     mrb_ary_push(mrb, ary, element);

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -943,8 +943,8 @@ static inline mrb_value mrb_redis_get_ary_reply(redisReply *reply, mrb_state *mr
 {
   mrb_value ary = mrb_ary_new_capa(mrb, reply->elements);
   int ai = mrb_gc_arena_save(mrb);
-  int element_couter;
-  for (size_t element_couter = 0; element_couter < reply->elements; element_couter++) {
+  size_t element_couter;
+  for (element_couter = 0; element_couter < reply->elements; element_couter++) {
     mrb_value element = mrb_redis_get_reply(reply->element[element_couter], mrb);
     mrb_ary_push(mrb, ary, element);
     mrb_gc_arena_restore(mrb, ai);
@@ -967,8 +967,8 @@ static mrb_value mrb_redisAppendCommandArgv(mrb_state *mrb, mrb_value self)
   argv[0] = mrb_sym2name_len(mrb, command, &command_len);
   argvlen[0] = command_len;
 
-  int argc_current;
-  for (mrb_int argc_current = 1; argc_current < argc; argc_current++) {
+  mrb_int argc_current;
+  for (argc_current = 1; argc_current < argc; argc_current++) {
     mrb_value curr = mrb_str_to_str(mrb, mrb_argv[argc_current - 1]);
     argv[argc_current] = RSTRING_PTR(curr);
     argvlen[argc_current] = RSTRING_LEN(curr);


### PR DESCRIPTION
I got below error when I add `fPIC` to cflags.

```
/ngx_mruby/mruby/build/mrbgems/mruby-redis/src/mrb_redis.c:969:3: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
   for (mrb_int argc_current = 1; argc_current < argc; argc_current++) {
   ^
rake aborted!
Command failed with status (1): [gcc-4.9  -fPIC -DPIC -DMRBGEM_MRUBY_REDIS_...]
```

This PR avoids `error: 'for' loop initial declarations `.