### PR TITLE
Add tests and correct behaviors

### DIFF
--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -982,7 +982,7 @@ static mrb_value mrb_redis_zscore(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_redis_pub(mrb_state *mrb, mrb_value self)
 {
-  mrb_value channel, msg;
+  mrb_value channel, msg, res;
   redisContext *rc = DATA_PTR(self);
   const char *argv[3];
   size_t lens[3];
@@ -991,9 +991,15 @@ static mrb_value mrb_redis_pub(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "oo", &channel, &msg);
   CREATE_REDIS_COMMAND_ARG2(argv, lens, "PUBLISH", channel, msg);
   rr = redisCommandArgv(rc, 3, argv, lens);
-  freeReplyObject(rr);
 
-  return self;
+  if (rr->type == REDIS_REPLY_INTEGER) {
+    res = mrb_fixnum_value(rr->integer);
+  } else {
+    res = mrb_nil_value();
+  }
+
+  freeReplyObject(rr);
+  return res;
 }
 
 static mrb_value mrb_redis_close(mrb_state *mrb, mrb_value self)

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -564,6 +564,17 @@ assert("Redis#randomkey") do
   assert_equal "foo", r.randomkey
 end
 
+assert("Redis#ltrim") do
+  r = Redis.new HOST, PORT
+  r.rpush "mylist", "one"
+  r.rpush "mylist", "two"
+  r.rpush "mylist", "three"
+
+  r.ltrim "mylist", 1, -1
+
+  results = r.lrange "mylist", 0, -1
+  assert_equal ["two", "three"], results
+end
+
 # TODO: Add test
-# - ltrim
 # - publish

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -576,5 +576,8 @@ assert("Redis#ltrim") do
   assert_equal ["two", "three"], results
 end
 
-# TODO: Add test
-# - publish
+assert("Redis#publish") do
+  producer = Redis.new HOST, PORT
+
+  assert_equal 0, producer.publish("some_queue", "hello world")
+end

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -556,7 +556,14 @@ end
 #  assert_equal "60", ret_c
 #end
 
+assert("Redis#randomkey") do
+  r = Redis.new HOST, PORT
+  r.flushdb
+  r.set "foo", "bar"
+
+  assert_equal "foo", r.randomkey
+end
+
 # TODO: Add test
-# - randomkey
 # - ltrim
 # - publish


### PR DESCRIPTION
This PR adds tests for existing features.

While trying to cover `publish`, I noticed there was a discrepancy between what it actually returns (the redis object itself) and what Redis was actually returning (number of subscribed clients that received the messages), so I changed the behavior to match with the actual Redis implementation.