### PR TITLE
Add support for PF* commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,18 @@ client.exists?("key")
 TBD
 
 
+#### `Redis#flushall` [doc](http://redis.io/commands/flushall)
+
+```ruby
+client.flushall
+```
+
+
 #### `Redis#flushdb` [doc](http://redis.io/commands/flushdb)
 
-TBD
+```ruby
+client.flushdb
+```
 
 
 #### `Redis#get` [doc](http://redis.io/commands/get)

--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ number_of_internal_registers_altered = client.pfadd "hyperloglog_structure", "so
 approximated_number_of_unique_elements = client.pfcount "hyperloglog_structure"
 ```
 
+#### `Redis#pfmerge` [doc](http://redis.io/commands/pfmerge)
+
+```ruby
+client.pfmerge "hll3", "hll1", "hll2"
+```
+
 
 #### `Redis#queue` [doc](http://redis.io/commands/queue)
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ number_of_subscribed_clients = client.publish "queue", "some value"
 number_of_internal_registers_altered = client.pfadd "hyperloglog_structure", "some value"
 ```
 
+#### `Redis#pfcount` [doc](http://redis.io/commands/pfcount)
+
+```ruby
+approximated_number_of_unique_elements = client.pfcount "hyperloglog_structure"
+```
+
 
 #### `Redis#queue` [doc](http://redis.io/commands/queue)
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,16 @@ client.ltrim "logs", 1, -1
 
 #### `Redis#publish` [doc](http://redis.io/commands/publish)
 
-TBD
+```ruby
+number_of_subscribed_clients = client.publish "queue", "some value"
+```
+
+
+#### `Redis#pfadd` [doc](http://redis.io/commands/pfadd)
+
+```ruby
+number_of_internal_registers_altered = client.pfadd "hyperloglog_structure", "some value"
+```
 
 
 #### `Redis#queue` [doc](http://redis.io/commands/queue)

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -261,6 +261,17 @@ static mrb_value mrb_redis_flushdb(mrb_state *mrb, mrb_value self)
   return str;
 }
 
+static mrb_value mrb_redis_flushall(mrb_state *mrb, mrb_value self)
+{
+  redisContext *rc = DATA_PTR(self);
+  mrb_value str;
+  redisReply *rs = redisCommand(rc, "FLUSHALL");
+
+  str = mrb_str_new(mrb, rs->str, rs->len);
+  freeReplyObject(rs);
+  return str;
+}
+
 static mrb_value mrb_redis_randomkey(mrb_state *mrb, mrb_value self)
 {
   redisContext *rc = DATA_PTR(self);
@@ -1188,6 +1199,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, redis, "get", mrb_redis_get, MRB_ARGS_ANY());
   mrb_define_method(mrb, redis, "exists?", mrb_redis_exists, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, redis, "expire", mrb_redis_expire, MRB_ARGS_REQ(2));
+  mrb_define_method(mrb, redis, "flushall", mrb_redis_flushall, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "flushdb", mrb_redis_flushdb, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "randomkey", mrb_redis_randomkey, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "[]=", mrb_redis_set, MRB_ARGS_ANY());

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1053,6 +1053,24 @@ static mrb_value mrb_redis_pfcount(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(integer);
 }
 
+static mrb_value mrb_redis_pfmerge(mrb_state *mrb, mrb_value self)
+{
+  mrb_value dest_struct, src_struct1, src_struct2;
+  const char *argv[3];
+  size_t lens[3];
+  redisReply *rr;
+
+  redisContext *rc = DATA_PTR(self);
+
+  mrb_get_args(mrb, "ooo", &dest_struct, &src_struct1, &src_struct2);
+  CREATE_REDIS_COMMAND_ARG3(argv, lens, "PFMERGE", dest_struct, src_struct1, src_struct2);
+
+  rr = redisCommandArgv(rc, 4, argv, lens);
+  freeReplyObject(rr);
+
+  return self;
+}
+
 static mrb_value mrb_redis_close(mrb_state *mrb, mrb_value self)
 {
   redisContext *rc = DATA_PTR(self);
@@ -1281,6 +1299,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, redis, "zscore", mrb_redis_zscore, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, redis, "pfadd", mrb_redis_pfadd, MRB_ARGS_ANY());
   mrb_define_method(mrb, redis, "pfcount", mrb_redis_pfcount, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, redis, "pfmerge", mrb_redis_pfmerge, MRB_ARGS_REQ(3));
   mrb_define_method(mrb, redis, "publish", mrb_redis_pub, MRB_ARGS_ANY());
   mrb_define_method(mrb, redis, "close", mrb_redis_close, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "queue", mrb_redisAppendCommandArgv, (MRB_ARGS_REQ(1) | MRB_ARGS_REST()));

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1033,6 +1033,26 @@ static mrb_value mrb_redis_pfadd(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(integer);
 }
 
+static mrb_value mrb_redis_pfcount(mrb_state *mrb, mrb_value self)
+{
+  mrb_value key;
+  mrb_int integer;
+  const char *argv[3];
+  size_t lens[3];
+  redisReply *rr;
+
+  redisContext *rc = DATA_PTR(self);
+
+  mrb_get_args(mrb, "o", &key);
+  CREATE_REDIS_COMMAND_ARG1(argv, lens, "PFCOUNT", key);
+
+  rr = redisCommandArgv(rc, 2, argv, lens);
+  integer = rr->integer;
+  freeReplyObject(rr);
+
+  return mrb_fixnum_value(integer);
+}
+
 static mrb_value mrb_redis_close(mrb_state *mrb, mrb_value self)
 {
   redisContext *rc = DATA_PTR(self);
@@ -1260,6 +1280,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, redis, "zrevrank", mrb_redis_zrevrank, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, redis, "zscore", mrb_redis_zscore, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, redis, "pfadd", mrb_redis_pfadd, MRB_ARGS_ANY());
+  mrb_define_method(mrb, redis, "pfcount", mrb_redis_pfcount, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, redis, "publish", mrb_redis_pub, MRB_ARGS_ANY());
   mrb_define_method(mrb, redis, "close", mrb_redis_close, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "queue", mrb_redisAppendCommandArgv, (MRB_ARGS_REQ(1) | MRB_ARGS_REST()));

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1013,6 +1013,26 @@ static mrb_value mrb_redis_pub(mrb_state *mrb, mrb_value self)
   return res;
 }
 
+static mrb_value mrb_redis_pfadd(mrb_state *mrb, mrb_value self)
+{
+  mrb_value key, val;
+  mrb_int integer;
+  const char *argv[3];
+  size_t lens[3];
+  redisReply *rr;
+
+  redisContext *rc = DATA_PTR(self);
+
+  mrb_get_args(mrb, "oo", &key, &val);
+  CREATE_REDIS_COMMAND_ARG2(argv, lens, "PFADD", key, val);
+
+  rr = redisCommandArgv(rc, 3, argv, lens);
+  integer = rr->integer;
+  freeReplyObject(rr);
+
+  return mrb_fixnum_value(integer);
+}
+
 static mrb_value mrb_redis_close(mrb_state *mrb, mrb_value self)
 {
   redisContext *rc = DATA_PTR(self);
@@ -1239,6 +1259,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, redis, "zrank", mrb_redis_zrank, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, redis, "zrevrank", mrb_redis_zrevrank, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, redis, "zscore", mrb_redis_zscore, MRB_ARGS_REQ(2));
+  mrb_define_method(mrb, redis, "pfadd", mrb_redis_pfadd, MRB_ARGS_ANY());
   mrb_define_method(mrb, redis, "publish", mrb_redis_pub, MRB_ARGS_ANY());
   mrb_define_method(mrb, redis, "close", mrb_redis_close, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "queue", mrb_redisAppendCommandArgv, (MRB_ARGS_REQ(1) | MRB_ARGS_REST()));

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -613,3 +613,16 @@ assert("Redis#pfcount") do
 
   assert_equal 2, r.pfcount("foos")
 end
+
+assert("Redis#pfcount") do
+  r = Redis.new HOST, PORT
+  r.flushall
+  %w|a b c|.each { |val| r.pfadd "foos", val }
+  %w|c d e|.each { |val| r.pfadd "bars", val }
+
+  assert_equal 3, r.pfcount("foos")
+  assert_equal 3, r.pfcount("bars")
+  r.pfmerge "bags", "foos", "bars"
+
+  assert_equal 5, r.pfcount("bags")
+end

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -90,6 +90,23 @@ assert("Redis#expire") do
   assert_nil ret2
 end
 
+assert("Redis#flushall") do
+  r = Redis.new HOST, PORT
+  r.set "key1", "a"
+  r.set "key2", "b"
+  ret1 = r.exists? "key1"
+  ret2 = r.exists? "key2"
+  r.flushall
+  ret_after1 = r.exists? "key1"
+  ret_after2 = r.exists? "key2"
+  r.close
+
+  assert_true ret1
+  assert_true ret2
+  assert_false ret_after1
+  assert_false ret_after2
+end
+
 assert("Redis#flushdb") do
   r = Redis.new HOST, PORT
   r.set "key1", "a"

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -598,3 +598,10 @@ assert("Redis#publish") do
 
   assert_equal 0, producer.publish("some_queue", "hello world")
 end
+
+assert("Redis#pfadd") do
+  r = Redis.new HOST, PORT
+  assert_equal 1, r.pfadd("foos", "bar")
+  assert_equal 1, r.pfadd("foos", "baz")
+  assert_equal 0, r.pfadd("foos", "baz")
+end

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -605,3 +605,11 @@ assert("Redis#pfadd") do
   assert_equal 1, r.pfadd("foos", "baz")
   assert_equal 0, r.pfadd("foos", "baz")
 end
+
+assert("Redis#pfcount") do
+  r = Redis.new HOST, PORT
+  r.pfadd("foos", "bar")
+  r.pfadd("foos", "baz")
+
+  assert_equal 2, r.pfcount("foos")
+end


### PR DESCRIPTION
This PR implements `PF*` commands, utilizing HyperLogLog data structures in Redis:

* `PFADD hll foo` : Add an element
* `PFCOUNT hll` : Count (implicitly distinct) elements
* `PFMERGE hll3 hll1 hll2` : Merge two HLL data structures together

Also, `Redis#flushall` became handy so I added it to the mix (in a separate commit).