### PR TITLE
Fix assert name s/pfcount/pfmerge/

### DIFF
--- a/test/redis.rb
+++ b/test/redis.rb
@@ -614,7 +614,7 @@ assert("Redis#pfcount") do
   assert_equal 2, r.pfcount("foos")
 end
 
-assert("Redis#pfcount") do
+assert("Redis#pfmerge") do
   r = Redis.new HOST, PORT
   r.flushall
   %w|a b c|.each { |val| r.pfadd "foos", val }


### PR DESCRIPTION
The name of `assert("Redis#pfcount")` is duplicated. The latter seems to be Redis#pfcount, so I changed the assert name.