### PR TITLE
Fix: Declare valiables outside of for-loop

### DIFF
--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -754,7 +754,8 @@ static mrb_value mrb_redis_hmget(mrb_state *mrb, mrb_value self)
   argvlen[0] = sizeof("HMGET") - 1;
 
   int ai = mrb_gc_arena_save(mrb);
-  for (mrb_int argc_current = 1; argc_current < argc; argc_current++) {
+  mrb_int argc_current;
+  for (argc_current = 1; argc_current < argc; argc_current++) {
     mrb_value curr = mrb_str_to_str(mrb, mrb_argv[argc_current - 1]);
     argv[argc_current] = RSTRING_PTR(curr);
     argvlen[argc_current] = RSTRING_LEN(curr);
@@ -768,7 +769,9 @@ static mrb_value mrb_redis_hmget(mrb_state *mrb, mrb_value self)
   if (rr->type == REDIS_REPLY_ARRAY) {
     if (rr->elements > 0) {
       array = mrb_ary_new(mrb);
-      for (int i = 0; i < rr->elements; i++) {
+
+      int i;
+      for (i = 0; i < rr->elements; i++) {
         if (rr->element[i]->len > 0) {
           mrb_ary_push(mrb, array, mrb_str_new(mrb, rr->element[i]->str, rr->element[i]->len));
         } else {
@@ -798,7 +801,8 @@ static mrb_value mrb_redis_hmset(mrb_state *mrb, mrb_value self)
   argvlen[0] = sizeof("HMSET") - 1;
 
   int ai = mrb_gc_arena_save(mrb);
-  for (mrb_int argc_current = 1; argc_current < argc; argc_current++) {
+  mrb_int argc_current;
+  for (argc_current = 1; argc_current < argc; argc_current++) {
     mrb_value curr = mrb_str_to_str(mrb, mrb_argv[argc_current - 1]);
     argv[argc_current] = RSTRING_PTR(curr);
     argvlen[argc_current] = RSTRING_LEN(curr);


### PR DESCRIPTION
'for' loop initial declarations are only allowed in C99 or C11 mode.
[ngx_mruby](https://github.com/matsumoto-r/ngx_mruby) fails to test like the following: https://travis-ci.org/hfm/ngx_mruby/jobs/153750690#L1048-L1071