### PR TITLE
Allow Redis#pf* to add multiple arguments.

### DIFF
--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1073,18 +1073,32 @@ static mrb_value mrb_redis_pfadd(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_redis_pfcount(mrb_state *mrb, mrb_value self)
 {
-  mrb_value key;
-  mrb_int integer;
-  const char *argv[2];
-  size_t lens[2];
-  redisReply *rr;
+  mrb_value key, *mrb_rest_argv;
+  mrb_int argc = 0;
+
+  mrb_get_args(mrb, "o*", &key, &mrb_rest_argv, &argc);
+  argc += 2;
+
+  const char *argv[argc];
+  size_t argvlen[argc];
+  CREATE_REDIS_COMMAND_ARG1(argv, argvlen, "PFCOUNT", key);
+
+  if (argc > 2) {
+    int ai = mrb_gc_arena_save(mrb);
+    mrb_int argc_current;
+    for (argc_current = 2; argc_current < argc; argc_current++) {
+      mrb_value curr = mrb_str_to_str(mrb, mrb_rest_argv[argc_current - 2]);
+      argv[argc_current] = RSTRING_PTR(curr);
+      argvlen[argc_current] = RSTRING_LEN(curr);
+      mrb_gc_arena_restore(mrb, ai);
+    }
+  }
 
   redisContext *rc = DATA_PTR(self);
+  redisReply *rr;
+  rr = redisCommandArgv(rc, argc, argv, argvlen);
 
-  mrb_get_args(mrb, "o", &key);
-  CREATE_REDIS_COMMAND_ARG1(argv, lens, "PFCOUNT", key);
-
-  rr = redisCommandArgv(rc, 2, argv, lens);
+  mrb_int integer;
   integer = rr->integer;
   freeReplyObject(rr);
 
@@ -1337,7 +1351,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, redis, "zrevrank", mrb_redis_zrevrank, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, redis, "zscore", mrb_redis_zscore, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, redis, "pfadd", mrb_redis_pfadd, (MRB_ARGS_REQ(1) | MRB_ARGS_REST()));
-  mrb_define_method(mrb, redis, "pfcount", mrb_redis_pfcount, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, redis, "pfcount", mrb_redis_pfcount, (MRB_ARGS_REQ(1) | MRB_ARGS_REST()));
   mrb_define_method(mrb, redis, "pfmerge", mrb_redis_pfmerge, MRB_ARGS_REQ(3));
   mrb_define_method(mrb, redis, "publish", mrb_redis_pub, MRB_ARGS_ANY());
   mrb_define_method(mrb, redis, "close", mrb_redis_close, MRB_ARGS_NONE());

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1040,13 +1040,13 @@ static mrb_value mrb_redis_pub(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_redis_pfadd(mrb_state *mrb, mrb_value self)
 {
   mrb_value key, *mrb_rest_argv;
-  mrb_int argc = 0;
+  mrb_int argc = 0, rest_argc = 0;
   redisContext *rc = DATA_PTR(self);
   redisReply *rr;
   mrb_int integer;
 
-  mrb_get_args(mrb, "o*", &key, &mrb_rest_argv, &argc);
-  argc += 2;
+  mrb_get_args(mrb, "o*", &key, &mrb_rest_argv, &rest_argc);
+  argc = rest_argc + 2;
 
   const char *argv[argc];
   size_t argvlen[argc];
@@ -1073,13 +1073,13 @@ static mrb_value mrb_redis_pfadd(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_redis_pfcount(mrb_state *mrb, mrb_value self)
 {
   mrb_value key, *mrb_rest_argv;
-  mrb_int argc = 0;
+  mrb_int argc = 0, rest_argc = 0;
   redisContext *rc = DATA_PTR(self);
   redisReply *rr;
   mrb_int integer;
 
-  mrb_get_args(mrb, "o*", &key, &mrb_rest_argv, &argc);
-  argc += 2;
+  mrb_get_args(mrb, "o*", &key, &mrb_rest_argv, &rest_argc);
+  argc = rest_argc + 2;
 
   const char *argv[argc];
   size_t argvlen[argc];
@@ -1106,12 +1106,12 @@ static mrb_value mrb_redis_pfcount(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_redis_pfmerge(mrb_state *mrb, mrb_value self)
 {
   mrb_value dest_struct, src_struct, *mrb_rest_argv;
-  mrb_int argc = 0;
+  mrb_int argc = 0, rest_argc = 0;
   redisContext *rc = DATA_PTR(self);
   redisReply *rr;
 
-  mrb_get_args(mrb, "oo*", &dest_struct, &src_struct, &mrb_rest_argv, &argc);
-  argc += 3;
+  mrb_get_args(mrb, "oo*", &dest_struct, &src_struct, &mrb_rest_argv, &rest_argc);
+  argc = rest_argc + 3;
 
   const char *argv[argc];
   size_t argvlen[argc];

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1041,6 +1041,9 @@ static mrb_value mrb_redis_pfadd(mrb_state *mrb, mrb_value self)
 {
   mrb_value key, *mrb_rest_argv;
   mrb_int argc = 0;
+  redisContext *rc = DATA_PTR(self);
+  redisReply *rr;
+  mrb_int integer;
 
   mrb_get_args(mrb, "o*", &key, &mrb_rest_argv, &argc);
   argc += 2;
@@ -1060,11 +1063,7 @@ static mrb_value mrb_redis_pfadd(mrb_state *mrb, mrb_value self)
     }
   }
 
-  redisContext *rc = DATA_PTR(self);
-  redisReply *rr;
   rr = redisCommandArgv(rc, argc, argv, argvlen);
-
-  mrb_int integer;
   integer = rr->integer;
   freeReplyObject(rr);
 
@@ -1075,6 +1074,9 @@ static mrb_value mrb_redis_pfcount(mrb_state *mrb, mrb_value self)
 {
   mrb_value key, *mrb_rest_argv;
   mrb_int argc = 0;
+  redisContext *rc = DATA_PTR(self);
+  redisReply *rr;
+  mrb_int integer;
 
   mrb_get_args(mrb, "o*", &key, &mrb_rest_argv, &argc);
   argc += 2;
@@ -1094,11 +1096,7 @@ static mrb_value mrb_redis_pfcount(mrb_state *mrb, mrb_value self)
     }
   }
 
-  redisContext *rc = DATA_PTR(self);
-  redisReply *rr;
   rr = redisCommandArgv(rc, argc, argv, argvlen);
-
-  mrb_int integer;
   integer = rr->integer;
   freeReplyObject(rr);
 
@@ -1109,6 +1107,8 @@ static mrb_value mrb_redis_pfmerge(mrb_state *mrb, mrb_value self)
 {
   mrb_value dest_struct, src_struct, *mrb_rest_argv;
   mrb_int argc = 0;
+  redisContext *rc = DATA_PTR(self);
+  redisReply *rr;
 
   mrb_get_args(mrb, "oo*", &dest_struct, &src_struct, &mrb_rest_argv, &argc);
   argc += 3;
@@ -1128,8 +1128,6 @@ static mrb_value mrb_redis_pfmerge(mrb_state *mrb, mrb_value self)
     }
   }
 
-  redisContext *rc = DATA_PTR(self);
-  redisReply *rr;
   rr = redisCommandArgv(rc, argc, argv, argvlen);
   if (rr->type == REDIS_REPLY_STRING) {
     mrb_value str = mrb_str_new(mrb, rr->str, rr->len);

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -647,12 +647,18 @@ end
 assert("Redis#pfmerge") do
   r = Redis.new HOST, PORT
   r.flushall
-  r.pfadd("foos", "a", "b", "c")
-  r.pfadd("bars", "c", "d", "e")
-  r.pfmerge "bazs", "foos"
-  r.pfmerge "foobars", "foos", "bars"
+  r.pfadd("foo", "a", "b", "c")
+  r.pfadd("bar", "c", "d", "e")
+  r.pfadd("baz", "e", "f", "g")
+
+  assert_raise(ArgumentError) {r.pfmerge }
+  assert_raise(ArgumentError) {r.pfmerge "foobar" }
+
+  r.pfmerge "foos", "foo"
+  r.pfmerge "foobar", "foo", "bar"
+  r.pfmerge "foobarbaz", "foo", "bar", "baz", "foobar"
 
   assert_equal 3, r.pfcount("foos")
-  assert_equal 3, r.pfcount("bazs")
-  assert_equal 5, r.pfcount("bags")
+  assert_equal 5, r.pfcount("foobar")
+  assert_equal 7, r.pfcount("foobarbaz")
 end

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -633,12 +633,15 @@ end
 
 assert("Redis#pfcount") do
   r = Redis.new HOST, PORT
+  r.flushall
   r.pfadd("foos", "bar")
   r.pfadd("foos", "baz")
   r.pfadd("bars", "foobar")
 
   assert_equal 2, r.pfcount("foos")
   assert_equal 3, r.pfcount("foos", "bars")
+  assert_equal 3, r.pfcount("foos", "bars", "barz")
+  assert_raise(ArgumentError) {r.pfcount }
 end
 
 assert("Redis#pfmerge") do

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -624,25 +624,29 @@ assert("Redis#pfadd") do
   assert_equal 1, r.pfadd("foos", "bar")
   assert_equal 1, r.pfadd("foos", "baz")
   assert_equal 0, r.pfadd("foos", "baz")
+  assert_equal 1, r.pfadd("foos", "foobar", "foobaz")
+  assert_equal 0, r.pfadd("foos", "foobar", "foobaz")
 end
 
 assert("Redis#pfcount") do
   r = Redis.new HOST, PORT
   r.pfadd("foos", "bar")
   r.pfadd("foos", "baz")
+  r.pfadd("bars", "foobar")
 
   assert_equal 2, r.pfcount("foos")
+  assert_equal 3, r.pfcount("foos", "bars")
 end
 
 assert("Redis#pfmerge") do
   r = Redis.new HOST, PORT
   r.flushall
-  %w|a b c|.each { |val| r.pfadd "foos", val }
-  %w|c d e|.each { |val| r.pfadd "bars", val }
+  r.pfadd("foos", "a", "b", "c")
+  r.pfadd("bars", "c", "d", "e")
+  r.pfmerge "bazs", "foos"
+  r.pfmerge "foobars", "foos", "bars"
 
   assert_equal 3, r.pfcount("foos")
-  assert_equal 3, r.pfcount("bars")
-  r.pfmerge "bags", "foos", "bars"
-
+  assert_equal 3, r.pfcount("bazs")
   assert_equal 5, r.pfcount("bags")
 end

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -621,11 +621,14 @@ end
 
 assert("Redis#pfadd") do
   r = Redis.new HOST, PORT
+  assert_equal 1, r.pfadd("foos")
+  assert_equal 0, r.pfadd("foos")
   assert_equal 1, r.pfadd("foos", "bar")
   assert_equal 1, r.pfadd("foos", "baz")
   assert_equal 0, r.pfadd("foos", "baz")
   assert_equal 1, r.pfadd("foos", "foobar", "foobaz")
   assert_equal 0, r.pfadd("foos", "foobar", "foobaz")
+  assert_raise(ArgumentError) {r.pfadd }
 end
 
 assert("Redis#pfcount") do


### PR DESCRIPTION
I reimplemented Redis#pf* methods.

- Allow [Redis#pfadd](http://redis.io/commands/pfadd) to specify multiple elementns.
- Allow [Redis#pfcount](http://redis.io/commands/pfcount) to add multiple keys.
- Allow [Redis#pfmerge](http://redis.io/commands/pfmerge) to add multiple sourcekeys.